### PR TITLE
Using ActionLink rather than ActionList

### DIFF
--- a/asp-dotnet-mvc/views.md
+++ b/asp-dotnet-mvc/views.md
@@ -90,7 +90,7 @@ public ActionResult Index() {
       
       <p>Having a party!!!</p>
       
-      @Html.ActionList("RSVP Now", "RsvpForm")
+      @Html.ActionLink("RSVP Now", "RsvpForm")
     </div>
   </body>
   ```


### PR DESCRIPTION
Resolves issue where tutorial referenced `ActionLink`, but in the code snippet used `ActionList`
see: https://github.com/byu-is-403/syllabus/pull/24

cc@ @asmockler 
